### PR TITLE
Added APPLICATION_URL to URLs

### DIFF
--- a/resources/js/input.js
+++ b/resources/js/input.js
@@ -13,7 +13,7 @@ $(function () {
 
             modal.find('.modal-content').append('<div class="modal-loading"><div class="active loader"></div></div>');
 
-            wrapper.find('.selected').load('/streams/file-field_type/selected?uploaded=' + $(this).data('file'), function () {
+            wrapper.find('.selected').load(APPLICATION_URL + '/streams/file-field_type/selected?uploaded=' + $(this).data('file'), function () {
                 modal.modal('hide');
             });
 
@@ -26,7 +26,7 @@ $(function () {
 
             $('[name="' + field + '"]').val('');
 
-            wrapper.find('.selected').load('/streams/file-field_type/selected', function () {
+            wrapper.find('.selected').load(APPLICATION_URL + '/streams/file-field_type/selected', function () {
                 modal.modal('hide');
             });
         });

--- a/resources/js/upload.js
+++ b/resources/js/upload.js
@@ -12,7 +12,7 @@ $(function () {
     var dropzone = new Dropzone('.dropzone',
         {
             paramName: 'upload',
-            url: '/streams/file-field_type/handle',
+            url: APPLICATION_URL + '/streams/file-field_type/handle',
             headers: {
                 'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
             },
@@ -71,6 +71,6 @@ $(function () {
 
         uploader.find('.uploaded .modal-body').html(element.data('loading') + '...');
 
-        uploader.find('.uploaded').load('/streams/file-field_type/recent?uploaded=' + uploaded.join(','));
+        uploader.find('.uploaded').load(APPLICATION_URL + '/streams/file-field_type/recent?uploaded=' + uploaded.join(','));
     });
 });


### PR DESCRIPTION
Prepended a few URLs with `APPLICATION_URL` so they point to the right place if your installation isn't in the base directory. E.g. clicking the "Select" button by a file in the file selector used to come up with a 404 error as it was pointing to, for example, `localhost/streams/...` instead of `localhost/appname/streams`.

Same issue with files-field_type, will submit PR for that in a minute. Think all's okay in the files-module.
