### PR TITLE
slugify the id & data-target attributes

### DIFF
--- a/resources/views/input.twig
+++ b/resources/views/input.twig
@@ -2,22 +2,22 @@
 
 <a
         data-toggle="modal"
-        data-target="#{{ field_type.field_name }}-modal"
+        data-target="#{{ str_slug(field_type.field_name) }}-modal"
         class="btn btn-default btn-xs"
-        href="{{ url('streams/file-field_type/index/' ~ field_type.config_key) }}"
->{{ trans('anomaly.field_type.file::button.select_file') }}</a>
+        href="{{ url(field_type.index_path) }}"
+        >{{ trans('anomaly.field_type.file::button.select_file') }}</a>
 
 <a
         data-toggle="modal"
-        data-target="#{{ field_type.field_name }}-modal"
-        href="{{ url('streams/file-field_type/choose/' ~ field_type.config_key) }}"
+        data-target="#{{ str_slug(field_type.field_name) }}-modal"
+        href="{{ url(field_type.upload_path) }}"
         class="btn btn-success btn-xs"
->{{ trans('anomaly.field_type.file::button.upload') }}</a>
+        >{{ trans('anomaly.field_type.file::button.upload') }}</a>
 
 <input
         type="hidden"
         name="{{ field_type.input_name }}"
-        value="{{ field_type.value.id ?: field_type.value }}"
+        value="{{ field_type.value.id }}"
         {{ field_type.disabled ? 'disabled' }}
         {{ field_type.readonly ? 'readonly' }}>
 
@@ -25,7 +25,7 @@
     {{ field_type.value_table|raw }}
 </div>
 
-<div class="modal remote" id="{{ field_type.field_name }}-modal">
+<div class="modal remote" id="{{ str_slug(field_type.field_name) }}-modal">
     <div class="modal-dialog">
         <div class="modal-content"></div>
     </div>


### PR DESCRIPTION
This allows the field to be named as an array, e.g. 'logos-field[]'
