### PR TITLE
Update input.js

### DIFF
--- a/resources/js/input.js
+++ b/resources/js/input.js
@@ -14,7 +14,9 @@ $(function () {
 
             modal.find('.modal-content').append('<div class="modal-loading"><div class="active loader"></div></div>');
 
-            wrapper.find('.selected').load('/streams/file-field_type/selected?uploaded=' + $(this).data('file'));
+            wrapper.find('.selected').load('/streams/file-field_type/selected?uploaded=' + $(this).data('file'), function () {
+                modal.modal('hide');
+            });
 
             input.val($(this).data('file'));
         });
@@ -25,7 +27,9 @@ $(function () {
 
             input.val('');
 
-            wrapper.find('.selected').load('/streams/file-field_type/selected');
+            wrapper.find('.selected').load('/streams/file-field_type/selected', function () {
+                modal.modal('hide');
+            });
         });
     });
 });


### PR DESCRIPTION
Reverting removal of modal.modal('hide').  Modals are no longer closing properly after this commit.
