### PR TITLE
Fix Field Type template to work with multiple locales

### DIFF
--- a/resources/views/input.twig
+++ b/resources/views/input.twig
@@ -2,25 +2,25 @@
 
 {% if not (field_type.readonly) %}
     {% if field_type.config.mode in ['default', 'select'] %}
-        <a data-toggle="modal" data-target="#{{ field_type.field_name }}-modal" class="btn btn-info btn-xs"
+        <a data-toggle="modal" data-target="#{{ field_type.input_name }}-modal" class="btn btn-info btn-xs"
            href="{{ url('streams/file-field_type/index/' ~ field_type.config_key) }}">{{ trans('anomaly.field_type.file::button.select_file') }}</a>
     {% endif %}
 
     {% if field_type.config.mode in ['default', 'upload'] %}
         <a data-toggle="modal"
-           data-target="#{{ field_type.field_name }}-modal" {% if field_type.config.folders|length == 1 %} href="{{ url('streams/file-field_type/upload/' ~ field_type.config.folders|first) }}" {% else %} href="{{ url('streams/file-field_type/choose/' ~ field_type.config_key) }}" {% endif %}
+           data-target="#{{ field_type.input_name }}-modal" {% if field_type.config.folders|length == 1 %} href="{{ url('streams/file-field_type/upload/' ~ field_type.config.folders|first) }}" {% else %} href="{{ url('streams/file-field_type/choose/' ~ field_type.config_key) }}" {% endif %}
            class="btn btn-success btn-xs">{{ trans('anomaly.field_type.file::button.upload') }}</a>
     {% endif %}
 {% endif %}
 
 <input type="hidden" name="{{ field_type.input_name }}"
-       value="{{ field_type.value.id ?: field_type.value }}" {{ html_attributes(field_type.attributes) }} {{ field_type.disabled ? 'disabled' }} {{ field_type.readonly ? 'readonly' }}>
+       value="{{ field_type.value.id ?: field_type.value }}" data-field_name="{{ field_type.input_name }}" {{ html_attributes(field_type.attributes) }} {{ field_type.disabled ? 'disabled' }} {{ field_type.readonly ? 'readonly' }}>
 
 <div class="selected">
     {{ field_type.value_table|raw }}
 </div>
 
-<div class="modal remote" id="{{ field_type.field_name }}-modal">
+<div class="modal remote" id="{{ field_type.input_name }}-modal">
     <div class="modal-dialog modal-wide">
         <div class="modal-content"></div>
     </div>


### PR DESCRIPTION
Hi there, I have noticed an issue with the File Field Type when working across multiple locales in the admin.

The issue occurs on the entry edit/creation screen and affects the ability to select/upload files for multiple locales.

The Field Field Type modal only appears for the first locale, and not any of the others. So, for example, if I have two locales (in this order):`en` and `fr` - the modal will only appear when the `en` locale is active. If I switch to the `fr` locale and click Select or Upload the modal will not appear (although the dark overlay will).

After an investigation, this appears to be the case since the `data-target` value of the Select and Upload buttons are the same across each locale, and the modal div ID is the same across multiple locales.

This PR resolves this by replacing references to `{{ field_type.field_name }}` with `{{ field_type.input_name }}` in the rendering of the field type input field.

This means that each modal and Select and Upload buttons have will now have separate div ID and modal target references per locale such as `header_image_en` and `header_image_fr`.

I have tested this with version 2.2 of the file-field_type and PyroCMS 3.4.