### PR TITLE
Localizing the file field modal name

### DIFF
--- a/resources/js/input.js
+++ b/resources/js/input.js
@@ -8,7 +8,7 @@ $(document).on('ajaxComplete ready', function () {
         var input = $(this);
         var field = input.data('field_name');
         var wrapper = input.closest('.form-group');
-        var modal = $('#' + field + '-modal');
+        var modal = wrapper.find('#' + input.data('modal-name'));
 
         modal.on('click', '[data-file]', function (e) {
 

--- a/resources/views/input.twig
+++ b/resources/views/input.twig
@@ -1,20 +1,21 @@
 {{ asset_add('scripts.js', 'anomaly.field_type.file::js/input.js') }}
+{% set modal_name = "#{field_type.field_name}-#{field_type.locale}-modal" %}
 
 {% if field_type.config.mode in ['default', 'select'] %}
-<a data-toggle="modal" data-target="#{{ field_type.field_name }}-modal" class="btn btn-info btn-xs" href="{{ url('streams/file-field_type/index/' ~ field_type.config_key) }}">{{ trans('anomaly.field_type.file::button.select_file') }}</a>
+<a data-toggle="modal" data-target="#{{ modal_name }}" class="btn btn-info btn-xs" href="{{ url('streams/file-field_type/index/' ~ field_type.config_key) }}">{{ trans('anomaly.field_type.file::button.select_file') }}</a>
 {% endif %}
 
 {% if field_type.config.mode in ['default', 'upload'] %}
-<a data-toggle="modal" data-target="#{{ field_type.field_name }}-modal" {% if field_type.config.folders|length == 1 %} href="{{ url('streams/file-field_type/upload/' ~ field_type.config.folders|first) }}" {% else %} href="{{ url('streams/file-field_type/choose/' ~ field_type.config_key) }}" {% endif %} class="btn btn-success btn-xs">{{ trans('anomaly.field_type.file::button.upload') }}</a>
+<a data-toggle="modal" data-target="#{{ modal_name }}" {% if field_type.config.folders|length == 1 %} href="{{ url('streams/file-field_type/upload/' ~ field_type.config.folders|first) }}" {% else %} href="{{ url('streams/file-field_type/choose/' ~ field_type.config_key) }}" {% endif %} class="btn btn-success btn-xs">{{ trans('anomaly.field_type.file::button.upload') }}</a>
 {% endif %}
 
-<input type="hidden" name="{{ field_type.input_name }}" value="{{ field_type.value.id ?: field_type.value }}" {{ html_attributes(field_type.attributes) }} {{ field_type.disabled ? 'disabled' }} {{ field_type.readonly ? 'readonly' }}>
+<input type="hidden" name="{{ field_type.input_name }}" value="{{ field_type.value.id ?: field_type.value }}" {{ html_attributes(field_type.attributes) }} {{ field_type.disabled ? 'disabled' }} {{ field_type.readonly ? 'readonly' }} data-modal-name="{{ modal_name }}">
 
 <div class="selected">
     {{ field_type.value_table|raw }}
 </div>
 
-<div class="modal remote" id="{{ field_type.field_name }}-modal">
+<div class="modal remote" id="{{ modal_name }}">
     <div class="modal-dialog modal-wide">
         <div class="modal-content"></div>
     </div>


### PR DESCRIPTION
When localizing images, currently the HTML `id` of the modal has the same value for each instance of the input in the admin.  This makes a locale-specific id name which fixes issues I was having when using an image input in other locales than the default one.