### PR TITLE
Fix upload when using fixed folder

### DIFF
--- a/resources/views/input.twig
+++ b/resources/views/input.twig
@@ -9,7 +9,7 @@
 
     {% if field_type.config.mode in ['default', 'upload'] %}
         <a data-toggle="modal"
-           data-target="#{{ field_type.input_name }}-modal" {% if field_type.config.folders|length == 1 %} href="{{ url('streams/file-field_type/upload/' ~ field_type.config.folders|first) }}" {% else %} href="{{ url('streams/file-field_type/choose/' ~ field_type.config_key) }}" {% endif %}
+           data-target="#{{ field_type.input_name }}-modal" {% if field_type.config.folders|length == 1 %} href="{{ url('streams/file-field_type/upload/' ~ field_type.config.folders|first) ~ '/' ~ field_type.config_key}}" {% else %} href="{{ url('streams/file-field_type/choose/' ~ field_type.config_key) }}" {% endif %}
            class="btn btn-success btn-xs">{{ trans('anomaly.field_type.file::button.upload') }}</a>
     {% endif %}
 {% endif %}

--- a/src/FileFieldTypeServiceProvider.php
+++ b/src/FileFieldTypeServiceProvider.php
@@ -27,13 +27,13 @@ class FileFieldTypeServiceProvider extends AddonServiceProvider
      * @var array
      */
     protected $routes = [
-        'streams/file-field_type/index/{key}'     => 'Anomaly\FileFieldType\Http\Controller\FilesController@index',
-        'streams/file-field_type/choose/{key}'    => 'Anomaly\FileFieldType\Http\Controller\FilesController@choose',
-        'streams/file-field_type/selected'        => 'Anomaly\FileFieldType\Http\Controller\FilesController@selected',
-        'streams/file-field_type/exists/{folder}' => 'Anomaly\FileFieldType\Http\Controller\FilesController@exists',
-        'streams/file-field_type/upload/{folder}' => 'Anomaly\FileFieldType\Http\Controller\UploadController@index',
-        'streams/file-field_type/handle'          => 'Anomaly\FileFieldType\Http\Controller\UploadController@upload',
-        'streams/file-field_type/recent'          => 'Anomaly\FileFieldType\Http\Controller\UploadController@recent',
+        'streams/file-field_type/index/{key}'           => 'Anomaly\FileFieldType\Http\Controller\FilesController@index',
+        'streams/file-field_type/choose/{key}'          => 'Anomaly\FileFieldType\Http\Controller\FilesController@choose',
+        'streams/file-field_type/selected'              => 'Anomaly\FileFieldType\Http\Controller\FilesController@selected',
+        'streams/file-field_type/exists/{folder}'       => 'Anomaly\FileFieldType\Http\Controller\FilesController@exists',
+        'streams/file-field_type/upload/{folder}/{key}' => 'Anomaly\FileFieldType\Http\Controller\UploadController@index',
+        'streams/file-field_type/handle'                => 'Anomaly\FileFieldType\Http\Controller\UploadController@upload',
+        'streams/file-field_type/recent'                => 'Anomaly\FileFieldType\Http\Controller\UploadController@recent',
     ];
 
 }

--- a/src/Http/Controller/UploadController.php
+++ b/src/Http/Controller/UploadController.php
@@ -28,14 +28,15 @@ class UploadController extends AdminController
      *
      * @param UploadTableBuilder $table
      * @param $folder
+     * @param $key
      * @return \Illuminate\Contracts\View\View|mixed
      */
-    public function index(UploadTableBuilder $table, $folder)
+    public function index(UploadTableBuilder $table, $folder, $key)
     {
         /* @var FolderInterface $folder */
         $folder = dispatch_now(new GetFolder($folder));
 
-        $config = Crypt::decrypt(request('key'));
+        $config = Crypt::decrypt($key);
 
         $allowed = array_intersect( Arr::get($config, 'allowed_types', []), $folder->getAllowedTypes());
 


### PR DESCRIPTION
when you are using a fixed upload folder, we need to get the config key from the url, not from the request.